### PR TITLE
Added the enable-kvm options to qemu.

### DIFF
--- a/kvm-guests/common/qemu-kvm.sh
+++ b/kvm-guests/common/qemu-kvm.sh
@@ -96,7 +96,8 @@ $(qemu_kvm_path) -name ${name} \
  -device virtserialport,chardev=qga0,name=org.qemu.guest_agent.0 \
  -pidfile ${pidfile} \
  -D ${logfile} \
- -daemonize
+ -daemonize \
+ -enable-kvm
 EOS
 }
 


### PR DESCRIPTION
This is required when running a newer version of Qemu. I confirmed that adding the option doesn't pose a problem when running on Centos' version.