### PR TITLE
Fix vnet edge test

### DIFF
--- a/kvm-guests/execscript/vnet.legacy/01_core
+++ b/kvm-guests/execscript/vnet.legacy/01_core
@@ -1,1 +1,1 @@
-../vnet.core
+../vnet.vna.kvm-guest/


### PR DESCRIPTION
Since this week, the edge test is broken because the legacy machine's SSH settings are incorrect. They have to be the same as the VM1~6. This fixed it.