### PR TITLE
disable lxc.tty.

### DIFF
--- a/lxc-hosts/bootstrap-common.sh
+++ b/lxc-hosts/bootstrap-common.sh
@@ -17,7 +17,7 @@ function render_lxc_conf() {
 
   cat <<EOS
 lxc.utsname = ${hostname}
-lxc.tty = 6
+#lxc.tty = 6
 #lxc.pts = 1024
 lxc.network.type = veth
 lxc.network.flags = up


### PR DESCRIPTION
if lxc.tty disabled, lxc container(s) will run with over lxc-1.0.7.